### PR TITLE
Add Spectre server and agent scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+server/node_modules
+server/dist
+client/spectre-agent
+client/bin
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-Spectre SSH
+# Spectre
+
+Reference layout for a two-part remote command streaming stack:
+- **server/** — Node.js + TypeScript control plane built with Express and `ws`.
+- **client/** — Go-based agent designed to run on Linux and stream a PTY over WebSockets.
+
+Both components use WebSockets for interactive keystroke and output streaming. Agents authenticate using a shared token and provide a fingerprint derived from machine characteristics so the server can recognize reinstalls.
+
+## Quick Start
+1. Start the server (see `server/README.md` for details):
+   ```bash
+   cd server
+   npm install
+   npm run dev
+   ```
+2. Build and run the agent on a target machine:
+   ```bash
+   cd client
+   GOOS=linux GOARCH=amd64 go build -o spectre-agent
+   ./spectre-agent -server ws://localhost:8080/ws -token changeme
+   ```
+
+The server will log agent connections, maintain an in-memory registry of connected/disconnected agents, and allow pushing keystrokes to live PTY sessions.

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,32 @@
+# Spectre Agent (Go)
+
+A lightweight Go daemon that establishes a persistent WebSocket session with the Spectre control server and exposes a live pseudo-terminal for streaming keystrokes and output.
+
+## Features
+- Connects to the Spectre server over WebSockets with a shared auth token.
+- Sends a unique fingerprint derived from machine ID, MAC addresses, and NIC names to identify reinstalls.
+- Spawns a login shell inside a PTY to support interactive sessions (sudo prompts, terminal control codes, etc.).
+- Streams keystrokes from the server to the PTY and streams output back to the server.
+- Handles SIGINT/SIGTERM for clean shutdowns.
+
+## Building
+```bash
+cd client
+GOOS=linux GOARCH=amd64 go build -o spectre-agent ./...
+```
+The resulting `spectre-agent` binary can be dropped into `/usr/local/bin` on Linux hosts.
+
+## Running
+```bash
+./spectre-agent \
+  -server ws://localhost:8080/ws \
+  -token changeme
+```
+
+Flags:
+- `-server` — WebSocket endpoint of the Spectre server.
+- `-token` — Shared auth token expected by the server.
+
+## Notes
+- PTY mode enables proper handling of `sudo` password prompts and interactive programs.
+- The agent keeps running until terminated and will attempt to send heartbeats so the server can mark stale connections.

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,0 +1,3 @@
+module spectre-agent
+
+go 1.21

--- a/client/main.go
+++ b/client/main.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/gorilla/websocket"
+)
+
+const heartbeatInterval = 25 * time.Second
+
+// AgentMessage documents what the agent can receive from the server.
+type AgentMessage struct {
+	Type string `json:"type"`
+	Data string `json:"data,omitempty"`
+}
+
+// ServerMessage documents what the agent sends to the server.
+type ServerMessage struct {
+	Type        string         `json:"type"`
+	Token       string         `json:"token,omitempty"`
+	AgentID     string         `json:"agentId,omitempty"`
+	Fingerprint map[string]any `json:"fingerprint,omitempty"`
+	Data        string         `json:"data,omitempty"`
+}
+
+func main() {
+	server := flag.String("server", "ws://localhost:8080/ws", "Spectre server WebSocket endpoint")
+	token := flag.String("token", "changeme", "Auth token expected by the server")
+	flag.Parse()
+
+	fingerprint := collectFingerprint()
+	agentID := fingerprint["fingerprint"].(string)
+
+	dialCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.DefaultDialer.DialContext(dialCtx, *server, nil)
+	if err != nil {
+		log.Fatalf("failed to connect to server: %v", err)
+	}
+	defer conn.Close()
+
+	log.Printf("connected to %s", *server)
+
+	hello := ServerMessage{Type: "hello", Token: *token, AgentID: agentID, Fingerprint: fingerprint}
+	if err := conn.WriteJSON(hello); err != nil {
+		log.Fatalf("failed to send handshake: %v", err)
+	}
+
+	shell := startShell()
+	defer shell.Close()
+
+	errCh := make(chan error, 1)
+	go readFromServer(conn, shell, errCh)
+	go readFromPTY(conn, shell, errCh)
+	go sendHeartbeats(conn, errCh)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case sig := <-sigCh:
+		log.Printf("received signal %s, shutting down", sig)
+	case err := <-errCh:
+		log.Printf("connection closed: %v", err)
+	}
+}
+
+func startShell() *os.File {
+	c := &syscall.SysProcAttr{Setctty: true, Setsid: true}
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/bash"
+	}
+
+	cmd := exec.Command(shell)
+	cmd.Env = os.Environ()
+	cmd.SysProcAttr = c
+
+	ptm, err := pty.Start(cmd)
+	if err != nil {
+		log.Fatalf("failed to start shell: %v", err)
+	}
+	return ptm
+}
+
+func readFromServer(conn *websocket.Conn, ptm *os.File, errCh chan<- error) {
+	for {
+		var msg AgentMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			errCh <- err
+			return
+		}
+
+		switch msg.Type {
+		case "keystroke":
+			if _, err := ptm.Write([]byte(msg.Data)); err != nil {
+				errCh <- fmt.Errorf("write to pty failed: %w", err)
+				return
+			}
+		}
+	}
+}
+
+func readFromPTY(conn *websocket.Conn, ptm *os.File, errCh chan<- error) {
+	reader := bufio.NewReader(ptm)
+	buf := make([]byte, 2048)
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			payload := ServerMessage{Type: "output", Data: string(buf[:n])}
+			if err := conn.WriteJSON(payload); err != nil {
+				errCh <- err
+				return
+			}
+		}
+		if err != nil {
+			errCh <- err
+			return
+		}
+	}
+}
+
+func sendHeartbeats(conn *websocket.Conn, errCh chan<- error) {
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := conn.WriteJSON(ServerMessage{Type: "heartbeat"}); err != nil {
+			errCh <- err
+			return
+		}
+	}
+}
+
+func collectFingerprint() map[string]any {
+	hostname, _ := os.Hostname()
+	machineID := readFileTrim("/etc/machine-id")
+	macs, nics := listInterfaces()
+
+	h := sha1.New()
+	h.Write([]byte(hostname))
+	h.Write([]byte(machineID))
+	h.Write([]byte(strings.Join(macs, ",")))
+	h.Write([]byte(strings.Join(nics, ",")))
+	hash := hex.EncodeToString(h.Sum(nil))
+
+	return map[string]any{
+		"hostname":     hostname,
+		"machineId":    machineID,
+		"macAddresses": macs,
+		"nics":         nics,
+		"fingerprint":  hash,
+	}
+}
+
+func readFileTrim(path string) string {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(bytes))
+}
+
+func listInterfaces() ([]string, []string) {
+	ifs, err := net.Interfaces()
+	if err != nil {
+		return nil, nil
+	}
+	macs := []string{}
+	nics := []string{}
+	for _, iface := range ifs {
+		nics = append(nics, iface.Name)
+		if len(iface.HardwareAddr) > 0 {
+			macs = append(macs, iface.HardwareAddr.String())
+		}
+	}
+	return macs, nics
+}

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,34 @@
+# Spectre Control Server
+
+A Node.js + TypeScript control plane that keeps track of connected Spectre agents, exposes a WebSocket endpoint for bi-directional terminal streaming, and provides REST endpoints for administrative actions.
+
+## Features
+- Express HTTP server with WebSocket upgrade endpoint using `ws`.
+- Token-based authentication for agents during handshake.
+- Tracks connected/disconnected agents and exposes `/agents` listing.
+- Provides a `/agents/:id/command` endpoint to push keystrokes or commands to an agent's pseudo-terminal session.
+- In-memory registry for demo purposes; swap with persistent storage or a message bus for production.
+
+## Getting Started
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Set the `AGENT_AUTH_TOKEN` environment variable to match the token configured on agents.
+
+## API
+- `GET /agents` — Lists known agents with connection status and fingerprint metadata.
+- `POST /agents/:id/command` — Pushes keystrokes/command text to the agent. Body: `{ "data": "ls -la\n" }`.
+- WebSocket endpoint: `ws://<host>:<port>/ws`. Agents send a `hello` frame on connect.
+
+## Project Structure
+- `src/server.ts` — Express setup, WebSocket handling, and in-memory agent registry.
+- `src/types.ts` — Shared message/agent types used by the server.
+
+## Notes
+- This implementation is intentionally simple and keeps state in memory. For a real deployment, plug in durable storage and a permission model for operator sessions.
+- The server currently trusts a single shared token. Replace with JWT or mTLS for stronger identity.

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "spectre-server",
+  "version": "0.1.0",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "uuid": "^9.0.1",
+    "ws": "^8.17.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.12",
+    "@types/ws": "^8.5.10",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,117 @@
+import express from "express";
+import { createServer } from "http";
+import { WebSocketServer, WebSocket } from "ws";
+import { v4 as uuid } from "uuid";
+import { AgentMessage, AgentRecord, ServerMessage } from "./types";
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 8080;
+const AUTH_TOKEN = process.env.AGENT_AUTH_TOKEN || "changeme";
+
+const app = express();
+app.use(express.json());
+
+const httpServer = createServer(app);
+const wss = new WebSocketServer({ server: httpServer, path: "/ws" });
+
+const agents: Map<string, { socket: WebSocket; record: AgentRecord }> = new Map();
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+function now() {
+  return Date.now();
+}
+
+wss.on("connection", (socket) => {
+  let agentId: string | undefined;
+
+  socket.on("message", (data) => {
+    try {
+      const payload = JSON.parse(data.toString()) as AgentMessage;
+      if (payload.type === "hello") {
+        if (payload.token !== AUTH_TOKEN) {
+          socket.close(4001, "unauthorized");
+          return;
+        }
+        agentId = payload.agentId || uuid();
+        const record: AgentRecord = {
+          id: agentId,
+          status: "connected",
+          lastSeen: now(),
+          fingerprint: payload.fingerprint,
+        };
+        agents.set(agentId, { socket, record });
+        console.log(`[agent ${agentId}] connected (${payload.fingerprint.hostname})`);
+        return;
+      }
+
+      if (!agentId) {
+        socket.close(4002, "missing handshake");
+        return;
+      }
+
+      const agentEntry = agents.get(agentId);
+      if (!agentEntry) return;
+      agentEntry.record.lastSeen = now();
+
+      if (payload.type === "output") {
+        console.log(`[agent ${agentId}] output: ${payload.data.substring(0, 120)}`);
+      }
+    } catch (err) {
+      console.error("invalid message", err);
+    }
+  });
+
+  socket.on("close", () => {
+    if (agentId) {
+      const existing = agents.get(agentId);
+      if (existing) {
+        existing.record.status = "disconnected";
+        existing.record.lastSeen = now();
+        agents.set(agentId, existing);
+      }
+      console.log(`[agent ${agentId}] disconnected`);
+    }
+  });
+});
+
+function pushToAgent(agentId: string, message: ServerMessage) {
+  const entry = agents.get(agentId);
+  if (!entry || entry.record.status !== "connected") {
+    throw new Error("agent not connected");
+  }
+  entry.socket.send(JSON.stringify(message));
+}
+
+app.get("/agents", (_req, res) => {
+  const records = Array.from(agents.values()).map((a) => a.record);
+  res.json(records);
+});
+
+app.post("/agents/:id/command", (req, res) => {
+  const { id } = req.params;
+  const { data } = req.body as { data?: string };
+  if (!data) {
+    return res.status(400).json({ error: "missing data" });
+  }
+  try {
+    pushToAgent(id, { type: "keystroke", data });
+    res.json({ status: "sent" });
+  } catch (err) {
+    res.status(404).json({ error: (err as Error).message });
+  }
+});
+
+setInterval(() => {
+  for (const [id, entry] of agents.entries()) {
+    if (entry.record.status !== "connected") continue;
+    try {
+      entry.socket.send(JSON.stringify({ type: "ping" } satisfies ServerMessage));
+    } catch (err) {
+      console.warn(`failed to ping agent ${id}`, err);
+    }
+  }
+}, HEARTBEAT_INTERVAL_MS);
+
+httpServer.listen(PORT, () => {
+  console.log(`Spectre server listening on :${PORT}`);
+});

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,24 @@
+export type AgentStatus = "connected" | "disconnected";
+
+export interface AgentFingerprint {
+  hostname: string;
+  machineId?: string;
+  macAddresses: string[];
+  nics: string[];
+}
+
+export interface AgentRecord {
+  id: string;
+  status: AgentStatus;
+  lastSeen: number;
+  fingerprint: AgentFingerprint;
+}
+
+export type ServerMessage =
+  | { type: "keystroke"; data: string }
+  | { type: "ping" };
+
+export type AgentMessage =
+  | { type: "hello"; token: string; agentId: string; fingerprint: AgentFingerprint }
+  | { type: "output"; data: string }
+  | { type: "heartbeat" };

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Node.js + TypeScript control server with WebSocket handling, agent registry, and REST endpoint for streaming keystrokes
- add a Go-based PTY agent that authenticates with a shared token, fingerprints the host, and streams terminal I/O over WebSockets
- document repository layout and usage for both server and agent while ignoring build artifacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a448bd6748328877c00a44d7bd33b)