### PR TITLE
Add tests across agent, server, and client apps

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,3 +1,8 @@
 module spectre-agent
 
 go 1.21
+
+require (
+        github.com/creack/pty v1.1.23
+        github.com/gorilla/websocket v1.5.1
+)

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestReadFileTrim(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "spectre-agent-test")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	content := "example data\n\n"
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+
+	trimmed := readFileTrim(tmpFile.Name())
+	if trimmed != strings.TrimSpace(content) {
+		t.Fatalf("expected %q, got %q", strings.TrimSpace(content), trimmed)
+	}
+
+	missing := readFileTrim("/path/does/not/exist")
+	if missing != "" {
+		t.Fatalf("expected empty string for missing file, got %q", missing)
+	}
+}
+
+func TestListInterfaces(t *testing.T) {
+	macs, nics := listInterfaces()
+	if len(nics) == 0 {
+		t.Fatalf("expected at least one network interface")
+	}
+	if len(macs) > len(nics) {
+		t.Fatalf("unexpected interface counts: macs=%d nics=%d", len(macs), len(nics))
+	}
+}

--- a/control-server/client/package.json
+++ b/control-server/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.2",
@@ -19,6 +20,9 @@
     "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
@@ -26,6 +30,7 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.2",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^2.1.1"
   }
 }

--- a/control-server/client/src/App.test.tsx
+++ b/control-server/client/src/App.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach, type Mock } from "vitest";
+import App, { formatTimestamp, statusVariant } from "./App";
+
+const originalFetch = global.fetch;
+
+describe("App helpers", () => {
+  it("formats timestamps in local time", () => {
+    const sample = new Date("2024-01-01T12:00:00Z").getTime();
+    expect(formatTimestamp(sample)).toBe(new Date(sample).toLocaleTimeString());
+  });
+
+  it("maps status to badge variants", () => {
+    expect(statusVariant("connected")).toBe("outline");
+    expect(statusVariant("connecting")).toBe("secondary");
+    expect(statusVariant("disconnected")).toBe("destructive");
+  });
+});
+
+describe("App component", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve([]),
+      }) as unknown as Promise<Response>,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("loads and displays empty state", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.getByText(/No connections yet/i)).toBeInTheDocument();
+  });
+
+  it("submits connection details", async () => {
+    const fetchMock = global.fetch as unknown as Mock;
+    const responses = [
+      Promise.resolve({ json: () => Promise.resolve([]) }),
+      Promise.resolve({ json: () => Promise.resolve({}) }),
+      Promise.resolve({ json: () => Promise.resolve([]) }),
+    ];
+    fetchMock.mockImplementation(() => responses.shift() as Promise<Response>);
+
+    render(<App />);
+
+    const addressInput = screen.getByLabelText(/Agent WebSocket URL/i);
+    fireEvent.change(addressInput, { target: { value: "ws://test/ws" } });
+    const tokenInput = screen.getByLabelText(/Token/i);
+    fireEvent.change(tokenInput, { target: { value: "secret" } });
+
+    const submit = screen.getByRole("button", { name: /connect/i });
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/agents/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ address: "ws://test/ws", token: "secret" }),
+    });
+  });
+});

--- a/control-server/client/src/App.tsx
+++ b/control-server/client/src/App.tsx
@@ -21,12 +21,12 @@ type Agent = {
   remoteAgentId?: string;
 };
 
-function formatTimestamp(ts: number) {
+export function formatTimestamp(ts: number) {
   const date = new Date(ts);
   return date.toLocaleTimeString();
 }
 
-function statusVariant(status: AgentStatus) {
+export function statusVariant(status: AgentStatus) {
   if (status === "connected") return "outline" as const;
   if (status === "connecting") return "secondary" as const;
   return "destructive" as const;

--- a/control-server/client/src/setupTests.ts
+++ b/control-server/client/src/setupTests.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/control-server/client/tsconfig.json
+++ b/control-server/client/tsconfig.json
@@ -10,7 +10,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/control-server/client/vite.config.ts
+++ b/control-server/client/vite.config.ts
@@ -3,4 +3,8 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.ts",
+  },
 });

--- a/control-server/server/package.json
+++ b/control-server/server/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "express": "^4.19.2",
@@ -16,7 +17,10 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.12.12",
     "@types/ws": "^8.5.10",
+    "@types/supertest": "^6.0.3",
+    "supertest": "^7.0.0",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.1"
   }
 }

--- a/control-server/server/src/server.test.ts
+++ b/control-server/server/src/server.test.ts
@@ -1,0 +1,76 @@
+import request from "supertest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createApp } from "./server";
+import { AgentRecord } from "./types";
+
+describe("createApp routes", () => {
+  let listAgents = vi.fn<[], AgentRecord[]>();
+  let connectToAgent = vi.fn<(address: string, token: string) => AgentRecord>();
+  let pushToAgent = vi.fn<(id: string, message: { type: "keystroke"; data: string }) => void>();
+
+  beforeEach(() => {
+    listAgents = vi.fn(() => []);
+    connectToAgent = vi.fn((address: string, token: string) => ({
+      id: "id-1",
+      address,
+      status: "connecting",
+      lastSeen: 123,
+      remoteAgentId: token,
+    }));
+    pushToAgent = vi.fn();
+  });
+
+  it("returns known agents", async () => {
+    const agents: AgentRecord[] = [
+      { id: "a1", address: "ws://example", status: "connected", lastSeen: 1 },
+    ];
+    listAgents = vi.fn(() => agents);
+
+    const app = createApp({ listAgents, connectToAgent, pushToAgent }, "token");
+    const res = await request(app).get("/agents");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(agents);
+    expect(listAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates connect request body", async () => {
+    const app = createApp({ listAgents, connectToAgent, pushToAgent }, "token");
+    const res = await request(app).post("/agents/connect").send({});
+
+    expect(res.status).toBe(400);
+    expect(connectToAgent).not.toHaveBeenCalled();
+  });
+
+  it("uses provided token or default", async () => {
+    const app = createApp({ listAgents, connectToAgent, pushToAgent }, "fallback");
+
+    await request(app)
+      .post("/agents/connect")
+      .send({ address: "ws://remote/ws" });
+    await request(app)
+      .post("/agents/connect")
+      .send({ address: "ws://remote/ws", token: "custom" });
+
+    expect(connectToAgent).toHaveBeenNthCalledWith(1, "ws://remote/ws", "fallback");
+    expect(connectToAgent).toHaveBeenNthCalledWith(2, "ws://remote/ws", "custom");
+  });
+
+  it("validates commands and forwards to push helper", async () => {
+    const app = createApp({ listAgents, connectToAgent, pushToAgent }, "token");
+
+    const missingRes = await request(app)
+      .post("/agents/abc/command")
+      .send({});
+    expect(missingRes.status).toBe(400);
+    expect(pushToAgent).not.toHaveBeenCalled();
+
+    const okRes = await request(app)
+      .post("/agents/abc/command")
+      .send({ data: "ls" });
+
+    expect(okRes.status).toBe(200);
+    expect(pushToAgent).toHaveBeenCalledWith("abc", { type: "keystroke", data: "ls" });
+    expect(okRes.body).toEqual({ status: "sent" });
+  });
+});

--- a/control-server/server/tsconfig.json
+++ b/control-server/server/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["vitest/node"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add Go unit coverage for the agent helper utilities and declare module dependencies
- refactor the control server to expose a testable app factory and cover its routes with Vitest
- introduce a Vitest/RTL setup for the React client with helper and form submission tests

## Testing
- go test ./... *(fails: missing go.sum entries because dependencies could not be downloaded in the restricted environment)*
- npm test --silent (control-server/server) *(fails: Vitest not installed due to npm registry 403 restrictions)*
- npm test --silent (control-server/client) *(fails: Vitest not installed due to npm registry 403 restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a57554a84832882227dc69a9a7e68)