### PR TITLE
Fix WebSocket connections between UI and control server

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -5,11 +5,9 @@ import { Button } from "./components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./components/ui/card";
 import type { Agent, AgentStatus } from "./state/agents";
 import { fetchAgents, subscribeToAgentEvents } from "./state/agents";
+import { getApiBase } from "./lib/api";
 
-const API_BASE =
-  (import.meta.env.VITE_API_BASE as string | undefined) && (import.meta.env.VITE_API_BASE as string).length > 0
-    ? (import.meta.env.VITE_API_BASE as string)
-    : window.location.origin;
+const API_BASE = getApiBase();
 
 export function formatTimestamp(ts: number) {
   const date = new Date(ts);

--- a/web-ui/src/components/AgentTerminal.tsx
+++ b/web-ui/src/components/AgentTerminal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
+import { buildWsUrl } from "../lib/api";
 
 type Props = {
   agentId: string;
@@ -14,14 +15,6 @@ type TerminalMessage =
   | { type: "output"; data: string }
   | { type: "status"; status: string; connectionId?: string }
   | { type: "error"; message: string };
-
-function buildSocketUrl(apiBase: string | undefined, agentId: string) {
-  const base = apiBase && apiBase.length > 0 ? apiBase : window.location.origin;
-  const url = new URL("/terminal", base);
-  url.protocol = url.protocol.replace("http", "ws");
-  url.searchParams.set("id", agentId);
-  return url.toString();
-}
 
 export function AgentTerminal({ agentId, apiBase, connectionId, enabled = true }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -115,7 +108,7 @@ export function AgentTerminal({ agentId, apiBase, connectionId, enabled = true }
     const connect = () => {
       if (cancelled) return;
       setStatus("connecting");
-      const socket = new WebSocket(buildSocketUrl(apiBase, agentId));
+      const socket = new WebSocket(buildWsUrl(`/terminal?id=${encodeURIComponent(agentId)}`, apiBase));
       socketRef.current = socket;
 
       term.writeln(`\r\n[connecting] ${agentId}`);

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -1,0 +1,15 @@
+const ENV_BASE =
+  (import.meta.env.VITE_API_BASE as string | undefined) && (import.meta.env.VITE_API_BASE as string).length > 0
+    ? (import.meta.env.VITE_API_BASE as string)
+    : undefined;
+
+export function getApiBase() {
+  return ENV_BASE ?? window.location.origin;
+}
+
+export function buildWsUrl(path: string, apiBase?: string) {
+  const base = apiBase && apiBase.length > 0 ? apiBase : getApiBase();
+  const url = new URL(path, base);
+  url.protocol = url.protocol.replace("http", "ws");
+  return url.toString();
+}

--- a/web-ui/src/pages/TerminalPage.tsx
+++ b/web-ui/src/pages/TerminalPage.tsx
@@ -4,11 +4,9 @@ import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { AgentTerminal } from "../components/AgentTerminal";
 import { Agent, fetchAgents, subscribeToAgentEvents } from "../state/agents";
+import { getApiBase } from "../lib/api";
 
-const API_BASE =
-  (import.meta.env.VITE_API_BASE as string | undefined) && (import.meta.env.VITE_API_BASE as string).length > 0
-    ? (import.meta.env.VITE_API_BASE as string)
-    : window.location.origin;
+const API_BASE = getApiBase();
 
 export default function TerminalPage() {
   const { id } = useParams<{ id: string }>();

--- a/web-ui/src/state/agents.ts
+++ b/web-ui/src/state/agents.ts
@@ -1,7 +1,6 @@
-const API_BASE =
-  (import.meta.env.VITE_API_BASE as string | undefined) && (import.meta.env.VITE_API_BASE as string).length > 0
-    ? (import.meta.env.VITE_API_BASE as string)
-    : window.location.origin;
+import { buildWsUrl, getApiBase } from "../lib/api";
+
+const API_BASE = getApiBase();
 
 export type AgentStatus = "connecting" | "connected" | "disconnected";
 export type AgentDirection = "inbound" | "outbound";
@@ -35,10 +34,7 @@ export type AgentEvent =
   | { type: "agent"; agent: Agent };
 
 function buildAgentEventsUrl(apiBase: string = API_BASE) {
-  const base = apiBase && apiBase.length > 0 ? apiBase : window.location.origin;
-  const url = new URL("/agents/events", base);
-  url.protocol = url.protocol.replace("http", "ws");
-  return url.toString();
+  return buildWsUrl("/agents/events", apiBase);
 }
 
 export function subscribeToAgentEvents(

--- a/web-ui/vite.config.js
+++ b/web-ui/vite.config.js
@@ -7,6 +7,12 @@ export default defineConfig({
             "/agents": {
                 target: "http://localhost:8080",
                 changeOrigin: true,
+                ws: true,
+            },
+            "/agents/events": {
+                target: "http://localhost:8080",
+                changeOrigin: true,
+                ws: true,
             },
             "/terminal": {
                 target: "http://localhost:8080",

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
         ws: true,
         secure: false,
       },
+      "/agents/events": {
+        target: CONTROL_SERVER_TARGET,
+        changeOrigin: true,
+        ws: true,
+        secure: false,
+      },
       "/terminal": {
         target: CONTROL_SERVER_TARGET,
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- centralize API base handling for HTTP and WebSocket URLs used by the web UI
- update terminal socket connections to use consistent URL builder
- ensure Vite dev proxy forwards agent event sockets in both config variants

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4b6297788328910bce239cff7151)