### PR TITLE
Fix outbound session handling and Vite config env typing

### DIFF
--- a/agent/terminal.go
+++ b/agent/terminal.go
@@ -33,15 +33,17 @@ func startShell() *os.File {
 }
 
 type ptySession struct {
-	mu   sync.RWMutex
-	ptm  *os.File
-	stop chan struct{}
+	mu        sync.RWMutex
+	ptm       *os.File
+	stop      chan struct{}
+	sessionID string
 }
 
-func newPtySession() *ptySession {
+func newPtySession(sessionID string) *ptySession {
 	return &ptySession{
-		ptm:  nil,
-		stop: make(chan struct{}),
+		ptm:       nil,
+		stop:      make(chan struct{}),
+		sessionID: sessionID,
 	}
 }
 
@@ -74,6 +76,47 @@ func (s *ptySession) reset() *os.File {
 	return s.ptm
 }
 
+type ptyManager struct {
+	mu       sync.RWMutex
+	sessions map[string]*ptySession
+}
+
+func newPtyManager() *ptyManager {
+	return &ptyManager{sessions: make(map[string]*ptySession)}
+}
+
+func (m *ptyManager) get(sessionID string) *ptySession {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sessions[sessionID]
+}
+
+func (m *ptyManager) reset(sessionID string) *ptySession {
+	m.mu.Lock()
+	session, ok := m.sessions[sessionID]
+	if !ok {
+		session = newPtySession(sessionID)
+		m.sessions[sessionID] = session
+	}
+	m.mu.Unlock()
+
+	session.reset()
+	return session
+}
+
+func (m *ptyManager) closeAll() {
+	m.mu.RLock()
+	sessions := make([]*ptySession, 0, len(m.sessions))
+	for _, session := range m.sessions {
+		sessions = append(sessions, session)
+	}
+	m.mu.RUnlock()
+
+	for _, session := range sessions {
+		session.close()
+	}
+}
+
 func (s *ptySession) close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -88,7 +131,7 @@ func (s *ptySession) close() {
 	}
 }
 
-func readFromControl(conn *websocket.Conn, session *ptySession, errCh chan<- error, restartPTY func(*os.File, <-chan struct{})) {
+func readFromControl(conn *websocket.Conn, sessions *ptyManager, errCh chan<- error, restartPTY func(*ptySession)) {
 	for {
 		var msg ControlMessage
 		if err := conn.ReadJSON(&msg); err != nil {
@@ -96,38 +139,47 @@ func readFromControl(conn *websocket.Conn, session *ptySession, errCh chan<- err
 			return
 		}
 
+		sessionID := msg.SessionID
+		if sessionID == "" {
+			sessionID = "default"
+		}
+
 		switch msg.Type {
 		case "keystroke":
+			session := sessions.get(sessionID)
+			if session == nil {
+				log.Printf("ignoring keystroke for unknown session %s", sessionID)
+				continue
+			}
 			ptm := session.current()
 			if ptm == nil {
-				errCh <- fmt.Errorf("no active pty (reset not requested yet)")
-				return
+				log.Printf("ignoring keystroke for inactive session %s", sessionID)
+				continue
 			}
 			if _, err := ptm.Write([]byte(msg.Data)); err != nil {
 				errCh <- fmt.Errorf("write to pty failed: %w", err)
 				return
 			}
 		case "reset":
-			newPTY := session.reset()
-			if newPTY != nil {
-				restartPTY(newPTY, session.stopChan())
-			}
+			session := sessions.reset(sessionID)
+			restartPTY(session)
 		}
 	}
 }
 
-func readFromPTY(conn *websocket.Conn, ptm *os.File, stop <-chan struct{}, errCh chan<- error) {
+func readFromPTY(conn *websocket.Conn, session *ptySession, errCh chan<- error) {
+	ptm := session.current()
 	reader := bufio.NewReader(ptm)
 	buf := make([]byte, 2048)
 	for {
 		select {
-		case <-stop:
+		case <-session.stopChan():
 			return
 		default:
 		}
 		n, err := reader.Read(buf)
 		if n > 0 {
-			payload := AgentMessage{Type: "output", Data: string(buf[:n])}
+			payload := AgentMessage{Type: "output", Data: string(buf[:n]), SessionID: session.sessionID}
 			if err := conn.WriteJSON(payload); err != nil {
 				errCh <- err
 				return
@@ -135,7 +187,7 @@ func readFromPTY(conn *websocket.Conn, ptm *os.File, stop <-chan struct{}, errCh
 		}
 		if err != nil {
 			select {
-			case <-stop:
+			case <-session.stopChan():
 				return
 			default:
 				errCh <- err

--- a/agent/types.go
+++ b/agent/types.go
@@ -9,6 +9,8 @@ type ControlMessage struct {
 	Type  string `json:"type"`
 	Token string `json:"token,omitempty"`
 	Data  string `json:"data,omitempty"`
+	// SessionID differentiates simultaneous PTY sessions.
+	SessionID string `json:"sessionId,omitempty"`
 }
 
 // AgentMessage documents what the agent sends to the control server.
@@ -17,4 +19,5 @@ type AgentMessage struct {
 	AgentID     string         `json:"agentId,omitempty"`
 	Fingerprint map[string]any `json:"fingerprint,omitempty"`
 	Data        string         `json:"data,omitempty"`
+	SessionID   string         `json:"sessionId,omitempty"`
 }

--- a/server/src/server.test.ts
+++ b/server/src/server.test.ts
@@ -6,7 +6,12 @@ import { AgentRecord } from "./types";
 describe("createApp routes", () => {
   let listAgents = vi.fn<[], AgentRecord[]>();
   let connectToAgent = vi.fn<(address: string, token: string) => AgentRecord>();
-  let pushToAgent = vi.fn<(id: string, message: { type: "keystroke"; data: string } | { type: "reset" }) => void>();
+  let pushToAgent = vi.fn<
+    (
+      id: string,
+      message: { type: "keystroke"; data: string; sessionId?: string } | { type: "reset"; sessionId?: string },
+    ) => void
+  >();
 
   beforeEach(() => {
     listAgents = vi.fn(() => []);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -21,10 +21,10 @@ export interface AgentRecord {
 
 export type ControlMessage =
   | { type: "hello"; token: string }
-  | { type: "keystroke"; data: string }
-  | { type: "reset" };
+  | { type: "keystroke"; data: string; sessionId?: string }
+  | { type: "reset"; sessionId?: string };
 
 export type AgentMessage =
   | { type: "hello"; agentId: string; fingerprint: AgentFingerprint }
-  | { type: "output"; data: string }
+  | { type: "output"; data: string; sessionId?: string }
   | { type: "heartbeat" };

--- a/web-ui/src/components/AgentTerminal.tsx
+++ b/web-ui/src/components/AgentTerminal.tsx
@@ -12,8 +12,8 @@ type Props = {
 };
 
 type TerminalMessage =
-  | { type: "output"; data: string }
-  | { type: "status"; status: string; connectionId?: string }
+  | { type: "output"; data: string; sessionId?: string }
+  | { type: "status"; status: string; connectionId?: string; sessionId?: string }
   | { type: "error"; message: string };
 
 export function AgentTerminal({ agentId, apiBase, connectionId, enabled = true }: Props) {
@@ -128,8 +128,8 @@ export function AgentTerminal({ agentId, apiBase, connectionId, enabled = true }
           } else if (payload.type === "status") {
             if (payload.status === "connected") {
               setStatus("connected");
-              if (payload.connectionId) {
-                setSessionId(payload.connectionId);
+              if (payload.sessionId || payload.connectionId) {
+                setSessionId(payload.sessionId ?? payload.connectionId ?? "");
               }
             } else if (payload.status === "connecting") {
               setStatus("connecting");

--- a/web-ui/vite.config.js
+++ b/web-ui/vite.config.js
@@ -1,28 +1,36 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+
+const CONTROL_SERVER_TARGET =
+  (typeof process !== "undefined" ? process.env?.CONTROL_SERVER_TARGET : undefined) ||
+  "http://127.0.0.1:8080";
+
 export default defineConfig({
-    plugins: [react()],
-    server: {
-        proxy: {
-            "/agents": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                ws: true,
-            },
-            "/agents/events": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                ws: true,
-            },
-            "/terminal": {
-                target: "http://localhost:8080",
-                ws: true,
-                changeOrigin: true,
-            },
-        },
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/agents": {
+        target: CONTROL_SERVER_TARGET,
+        changeOrigin: true,
+        ws: true,
+        secure: false,
+      },
+      "/agents/events": {
+        target: CONTROL_SERVER_TARGET,
+        changeOrigin: true,
+        ws: true,
+        secure: false,
+      },
+      "/terminal": {
+        target: CONTROL_SERVER_TARGET,
+        changeOrigin: true,
+        ws: true,
+        secure: false,
+      },
     },
-    test: {
-        environment: "jsdom",
-        setupFiles: "./src/setupTests.ts",
-    },
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.ts",
+  },
 });

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
-const CONTROL_SERVER_TARGET = process.env.CONTROL_SERVER_TARGET || "http://127.0.0.1:8080";
+declare const process: { env?: Record<string, string | undefined> };
+
+const CONTROL_SERVER_TARGET =
+  (typeof process !== "undefined" ? process.env?.CONTROL_SERVER_TARGET : undefined) ||
+  "http://127.0.0.1:8080";
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- align the outbound control client with the session-aware PTY manager and keep a default session for legacy traffic
- clean up the agent server imports
- make the Vite configs use an optional environment target without relying on Node type packages

## Testing
- go test ./...
- npm test (server)
- npm run build (server)
- npm test (web-ui)
- npm run build (web-ui)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4d7c27bc8328bc6f3ab3875fe134)